### PR TITLE
Feat#115/get date params

### DIFF
--- a/extension/scripts/screenConfig.js
+++ b/extension/scripts/screenConfig.js
@@ -7,6 +7,10 @@ let weights = [4,5,2,3] // default weights
 
 let sprintLength = 7
 
+let init_week_day
+
+let date_unix_time
+
 
 function getMetrics(updateRanking) 
 {
@@ -166,8 +170,11 @@ $(document).on("click", "#settingsSave", function()
     weights[1] = $('#commitsWeight').val()
     weights[2] = $('#openWeight').val()
     weights[3] = $('#commentsWeight').val()
+
     alert("Configurations saved!")
+
     getMetrics(true)
+
     $('#settingsButton').popover('hide')
 })
 

--- a/extension/scripts/screenConfig.js
+++ b/extension/scripts/screenConfig.js
@@ -170,8 +170,14 @@ $(document).on("click", "#settingsSave", function()
     weights[1] = $('#commitsWeight').val()
     weights[2] = $('#openWeight').val()
     weights[3] = $('#commentsWeight').val()
+    init_week_day = $('#weekdaylist').val()
+    date_unix_time = Math.floor(new Date($('#initdate').val()).getTime() / 1000)
 
     alert("Configurations saved!")
+
+    console.log(sprintLength)
+    console.log(init_week_day)
+    console.log(date_unix_time)
 
     getMetrics(true)
 

--- a/extension/scripts/screenPage.js
+++ b/extension/scripts/screenPage.js
@@ -2,6 +2,19 @@
 
 function gbdScreen()
 {
+    let today = new Date()
+    let dd = today.getDate()
+    let mm = today.getMonth()+1
+    let yyyy = today.getFullYear()
+
+    if (dd < 10)
+        dd='0'+dd
+    
+    if (mm < 10)
+        mm='0'+mm
+    
+    today = yyyy+'-'+mm+'-'+dd
+
     let urlLogo = chrome.extension.getURL("images/logo.jpg")
     let urlCog = chrome.extension.getURL("images/cog-8x.png")
     let gbdScreen = 
@@ -48,6 +61,22 @@ function gbdScreen()
                             <form style="margin-top: 8%;">
                                 <label for="SprintLength">Sprint length in days: </label>
                                 <input type="number" name="SprintLength" value="7" id="sprintLength" min="1" max="10">
+                            </form>
+                            <form style="margin-top: 8%;">
+                                <label for="InitialDay">Weekday that each sprint starts: </label>
+                                <select name="InitialDay" id="#weekdaylist">
+                                    <option value="0">Sunday</option>
+                                    <option value="1">Monday</option>
+                                    <option value="2">Tuesday</option>
+                                    <option value="3">Wednesday</option>
+                                    <option value="4">Thursday</option>
+                                    <option value="5">Friday</option>
+                                    <option value="6">Saturday</option>
+                                </select>
+                            </form>
+                            <form style="margin-top: 8%;">
+                                <label for="initdate">Starting date of sprint 1: </label>
+                                <input type="date" id="init_date" name="init_date" min="2019-01-01" max="${today}">
                             </form>
                         </div>
 

--- a/extension/scripts/screenPage.js
+++ b/extension/scripts/screenPage.js
@@ -64,7 +64,7 @@ function gbdScreen()
                             </form>
                             <form style="margin-top: 8%;">
                                 <label for="InitialDay">Weekday that each sprint starts: </label>
-                                <select name="InitialDay" id="#weekdaylist">
+                                <select name="InitialDay" id="weekdaylist">
                                     <option value="0">Sunday</option>
                                     <option value="1">Monday</option>
                                     <option value="2">Tuesday</option>
@@ -76,7 +76,7 @@ function gbdScreen()
                             </form>
                             <form style="margin-top: 8%;">
                                 <label for="initdate">Starting date of sprint 1: </label>
-                                <input type="date" id="init_date" name="init_date" min="2019-01-01" max="${today}">
+                                <input type="date" id="initdate" name="initdate" min="2019-01-01" max="${today}">
                             </form>
                         </div>
 


### PR DESCRIPTION
Nessa issue adicionamos dois novos campos a página de configurações, um para escolher o dia da semana em que cada sprint começa, e outra para escolher a data inicial das sprints (data da primeira sprint). Assim temos as 3 informações (a terceira já existia na tela, o tamanho da sprint) necessárias para separar as informações de commits por sprint.